### PR TITLE
Use env markers to only install typing when needed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     packages=find_packages(exclude=['.']),
     install_requires=[
         'pydantic',
-        'typing',
+        'typing;python_version<"3.5"',
         'typing_extensions',
         'datetime',
         'nvdlib'


### PR DESCRIPTION
Linked to https://github.com/avidml/avidtools/issues/6