### PR TITLE
chore(release): bump version to 0.3.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "avidtools"
-version = "0.3"
+version = "0.3.1"
 description = "Developer tools for AVID"
 authors = [
     {name = "Subho Majumdar", email = "subho@avidml.org"},


### PR DESCRIPTION
Sync package version on `main` after release publish.

- Release tag: `0.3.1`
- Updated `pyproject.toml` version: `0.3.1`